### PR TITLE
Add Media Server Selector with Custom URL Option

### DIFF
--- a/src/pages/settings/Mediaservers.tsx
+++ b/src/pages/settings/Mediaservers.tsx
@@ -1,0 +1,61 @@
+import { useLocalState } from "irisdb-hooks"
+import { ChangeEvent } from "react"
+
+function MediaServers() {
+  const [selectedServer, setSelectedServer] = useLocalState<string>(
+    "user/mediaserver",
+    "https://nostr.build/api/v2/nip96/upload",
+    String
+  )
+
+  function handleServerChange(e: ChangeEvent<HTMLSelectElement | HTMLInputElement>) {
+    setSelectedServer(e.target.value)
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl mb-4">Media Servers</h1>
+      <div className="flex flex-col gap-4">
+        <div>
+          <p>Select a NIP96 media provider</p>
+          <select
+            aria-label="Select a server"
+            className="select select-primary mt-2"
+            value={selectedServer}
+            onChange={handleServerChange}
+          >
+            <option value="https://nostr.build/api/v2/nip96/upload">
+              https://nostr.build
+            </option>
+            <option value="https://cdn.nostrcheck.me">https://nostrcheck.me</option>
+          </select>
+        </div>
+        <div>
+          <p>Server URL</p>
+          <input
+            type="url"
+            required
+            className="input input-bordered mt-2 text-lg w-full"
+            placeholder="https://cdn.nostrcheck.me"
+            value={selectedServer}
+            onChange={handleServerChange}
+          />
+          <p className="text-sm text-gray-500 mt-1">
+            You can specify a custom mediaserver URL, see{" "}
+            <a
+              href="https://github.com/aljazceru/awesome-nostr?tab=readme-ov-file#nip-96-file-storage-servers"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="link"
+            >
+              here
+            </a>{" "}
+            for more info.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default MediaServers

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -3,6 +3,7 @@ import {useLocation, Link, Routes, Route} from "react-router-dom"
 import {ProfileSettings} from "@/pages/settings/Profile.tsx"
 import NotificationSettings from "./NotificationSettings"
 import Appearance from "@/pages/settings/Appearance.tsx"
+import MediaServers from "@/pages/settings/Mediaservers.tsx"
 import IrisSettings from "./IrisAccount/IrisSettings"
 import {Network} from "@/pages/settings/Network.tsx"
 import {RiArrowRightSLine} from "@remixicon/react"
@@ -51,6 +52,12 @@ function Settings() {
           iconBg: "bg-purple-500",
           message: "Appearance",
           path: "/settings/appearance",
+        },
+        {
+          icon: "media",
+          iconBg: "bg-blue-500",
+          message: "Media Servers",
+          path: "/settings/mediaservers",
         },
         {
           icon: "hard-drive",
@@ -163,6 +170,7 @@ function Settings() {
             <Route path="wallet" element={<WalletSettings />} />
             <Route path="backup" element={<Backup />} />
             <Route path="appearance" element={<Appearance />} />
+            <Route path="mediaservers" element={<MediaServers />} />
             <Route path="social-graph" element={<SocialGraphSettings />} />
             <Route path="notifications" element={<NotificationSettings />} />
             <Route path="privacy" element={<PrivacySettings />} />

--- a/src/shared/upload.ts
+++ b/src/shared/upload.ts
@@ -1,6 +1,15 @@
 import socialGraph from "@/utils/socialGraph"
 import {NDKEvent} from "@nostr-dev-kit/ndk"
 import {ndk} from "@/utils/ndk"
+import {localState} from "irisdb"
+
+function getMediaServerUrl(): Promise<string> {
+  return new Promise((resolve) => {
+    localState.get("user/mediaserver").once((v) => {
+      resolve((v as string) || "https://nostr.build/api/v2/nip96/upload")
+    })
+  })
+}
 
 export async function uploadFile(
   file: File,
@@ -10,7 +19,8 @@ export async function uploadFile(
   fd.append("fileToUpload", file)
   fd.append("submit", "Upload Image")
 
-  const url = "https://nostr.build/api/v2/nip96/upload"
+  // Get the media server URL from localState
+  const url = await getMediaServerUrl()
 
   // Create a Nostr event for authentication
   const event = new NDKEvent(ndk(), {


### PR DESCRIPTION
# Add Media Server Selector with Custom URL Option

## Overview

This PR introduces a new Media Server Selector component that allows users to choose a default NIP96 media server or specify a custom server URL. The component offers two options:

- **Pre-defined Options:** A dropdown with pre-configured media server choices (currently "https://nostr.build/api/v2/nip96/upload" and "https://cdn.nostrcheck.me").
- **Custom URL:** An input field for a custom server URL, styled with larger text and accompanied by an explanatory note. When a custom URL is provided, it will override the default options.

![image](https://github.com/user-attachments/assets/01c83aa9-ca04-4221-8fa9-9394501c3e1b)


## Changes

- **MediaServers Component:**  
  - Added a new component that uses the `useLocalState` hook to store and manage the media server URL.
  - Integrated a `<select>` element for default media servers.
  - Added an `<input type="url">` field for users to enter a custom URL.

- **LocalState Integration:**  
  - The component reads from and writes to the `"user/mediaserver"` key in local storage.
  - A default value of `"https://nostr.build/api/v2/nip96/upload"` is used if no custom URL is set.
