### PR TITLE
Order chats based on time

### DIFF
--- a/src/pages/chats/list/ChatList.tsx
+++ b/src/pages/chats/list/ChatList.tsx
@@ -12,13 +12,18 @@ interface ChatListProps {
   className?: string
 }
 
+type LatestMessage = {
+  content: string
+  id: string
+  sender: string
+  created_at: number
+}
+
 type Session = {
-  messages: string[]
   deleted?: boolean
-  latest?: {
-    time: number
-    content: string
-  }
+  lastSeen?: number
+  events?: Record<string, unknown>
+  latest?: LatestMessage
 }
 
 type PublicChat = {
@@ -168,7 +173,7 @@ const ChatList = ({className}: ChatListProps) => {
     if (a.isPublic) {
       aLatest = publicChatTimestamps[a.id] || 0
     } else {
-      aLatest = sessions[a.id]?.latest?.time || 0
+      aLatest = sessions[a.id]?.latest?.created_at || 0
     }
 
     // Get latest message time for chat B
@@ -176,7 +181,7 @@ const ChatList = ({className}: ChatListProps) => {
     if (b.isPublic) {
       bLatest = publicChatTimestamps[b.id] || 0
     } else {
-      bLatest = sessions[b.id]?.latest?.time || 0
+      bLatest = sessions[b.id]?.latest?.created_at || 0
     }
 
     // Sort in descending order (newest first)

--- a/src/pages/chats/list/ChatList.tsx
+++ b/src/pages/chats/list/ChatList.tsx
@@ -45,11 +45,15 @@ const ChatList = ({className}: ChatListProps) => {
 
   useEffect(() => {
     localState.get("sessions").put({})
-    // TODO irisdb doesnt work right on initial update if we use recursion 3 param
-    const unsub = localState.get("sessions").on((sessions) => {
-      if (!sessions || typeof sessions !== "object") return
-      setSessions({...sessions} as Record<string, Session>)
-    })
+
+    const unsub = localState.get("sessions").on(
+      (sessions) => {
+        if (!sessions || typeof sessions !== "object") return
+        setSessions({...sessions} as Record<string, Session>)
+      },
+      false,
+      3
+    )
 
     // Get user's public key
     const unsubPubKey = localState.get("user/publicKey").on((key) => {
@@ -156,6 +160,10 @@ const ChatList = ({className}: ChatListProps) => {
       ...publicChats.map((chat) => ({id: chat.id, isPublic: true})),
     ].reduce(
       (acc, chat) => {
+        // If chat has empty string as id, skip it (appears on recursion depth 3 on sessions)
+        if (chat.id === "") {
+          return acc
+        }
         // If chat doesn't exist or current chat is newer, update it
         if (!acc[chat.id] || (chat.isPublic && !acc[chat.id].isPublic)) {
           acc[chat.id] = chat


### PR DESCRIPTION
- Uses as much of the existing sorting etc. as possible
  - Corrected message type so sort reads the right field
  - Increased recursion depth so `latest` is actually populated
- Tried to reproduce the issue of initial update but only ran into a different issue on later later updates
  - One chat with `""` id comes with the response when opening a chat (could not find the root cause yet) 
  - It should not cause an issue since this is just a read call and we can remove that chat. However, if there were another type of erroneous id, this doesn't account for it.
 
 Note: closed the first one to keep my fork main clean

https://github.com/user-attachments/assets/361e4e3f-553e-453d-b3ed-2ced66be8307
