### PR TITLE
Fix overflow in mobile chat with lower max-w

### DIFF
--- a/src/pages/chats/message/Message.tsx
+++ b/src/pages/chats/message/Message.tsx
@@ -151,7 +151,7 @@ const Message = ({
       )}
       id={message.id}
     >
-      <div className="flex items-center justify-center gap-2 max-w-[85%] md:max-w-[70%]">
+      <div className="flex items-center justify-center gap-2">
         {isUser && (
           <MessageReactionButton
             messageId={message.id}

--- a/src/pages/chats/message/ReplyPreview.tsx
+++ b/src/pages/chats/message/ReplyPreview.tsx
@@ -101,7 +101,7 @@ const ReplyPreview = ({isUser, sessionId, replyToId}: ReplyPreviewProps) => {
           />
         )}{" "}
       </div>
-      <div className="truncate max-w-[250px]">{repliedToMessage.content}</div>
+      <div className="truncate max-w-[225px]">{repliedToMessage.content}</div>
     </div>
   )
 }


### PR DESCRIPTION
- `Message.tsx` max widths caused reply previews to be misaligned
- `ReplyPreview.tsx` max width was slightly too much - percentage calculation doesn't work there so lowered the max width in `px`