### PR TITLE
Textarea for shift+enter newlines and text wrapping

### DIFF
--- a/src/shared/hooks/useAutosizeTextarea.ts
+++ b/src/shared/hooks/useAutosizeTextarea.ts
@@ -1,0 +1,19 @@
+import { useLayoutEffect, useRef } from "react"
+
+export function useAutosizeTextarea(
+  value: string,
+  { maxRows = 6 } = {}
+) {
+  const ref = useRef<HTMLTextAreaElement>(null)
+
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const line = parseFloat(getComputedStyle(el).lineHeight)
+    el.style.height = "auto" // Reset height to auto (resets after send or removing line)
+    el.style.height = Math.min(el.scrollHeight, line * maxRows) + "px"
+    el.style.textAlign = el.scrollHeight <= line + 1 ? "center" : "left"
+  }, [value, maxRows])
+
+  return ref
+} 

--- a/tests/message-form.spec.ts
+++ b/tests/message-form.spec.ts
@@ -1,0 +1,136 @@
+import {test, expect} from "@playwright/test"
+import {signUp} from "./auth.setup"
+
+async function setupChat(page) {
+  const createInviteButton = page.getByRole("button", {name: "Create Invite Link"})
+  await createInviteButton.click()
+  await page.waitForTimeout(2000) // Wait for invite creation
+
+  const qrButton = page.getByRole("button", {name: "Show QR Code"}).first()
+  await qrButton.click()
+  const inviteLink = await page.getByText(/^https:\/\/iris\.to/).textContent()
+  expect(inviteLink).toBeTruthy()
+  await page.keyboard.press("Escape")
+
+  const inviteInput = page.getByPlaceholder("Paste invite link")
+  await inviteInput.click()
+  await page.keyboard.type(inviteLink!)
+  await expect(page).toHaveURL(/\/chats\/chat/, {timeout: 10000})
+}
+
+test.describe("Message Form - Desktop", () => {
+  test.beforeEach(async ({page}) => {
+
+    await signUp(page)
+    await page.getByRole("link", {name: "Chats"}).click()
+    await expect(page.getByRole("banner").getByText("New Chat")).toBeVisible()
+  })
+
+  test("can send a basic text message using Enter key", async ({page}) => {
+    await setupChat(page)
+
+    const messageInput = page.getByPlaceholder("Message")
+    const testMessage = "Hello, this is a test message!"
+    await messageInput.fill(testMessage)
+    await messageInput.press("Enter")
+
+    await expect(page.getByRole("paragraph").filter({hasText: testMessage})).toBeVisible()
+
+    await expect(page.getByRole("button", {name: "Send message"})).not.toBeVisible()
+  })
+
+  test("empty message cannot be sent", async ({page}) => {
+    await setupChat(page)
+
+    const messageInput = page.getByPlaceholder("Message")
+    await messageInput.fill("   ") // Just spaces
+    await messageInput.press("Enter")
+
+    await expect(page.getByRole("paragraph").filter({hasText: "   "})).not.toBeVisible()
+  })
+
+  test("shift + enter adds a new line", async ({page}) => {
+    await setupChat(page)
+
+    const messageInput = page.getByPlaceholder("Message")
+    await messageInput.fill("Hello, this is a test message!")
+    await messageInput.press("Shift+Enter")
+
+    await expect(messageInput).toHaveValue("Hello, this is a test message!\n")
+  })
+
+  test("multiple shift + enter presses add multiple new lines", async ({page}) => {
+    await setupChat(page)
+
+    const messageInput = page.getByPlaceholder("Message")
+    await messageInput.pressSequentially("Hello, this is a test message!")
+    
+    await messageInput.press("Shift+Enter")
+    await messageInput.press("Shift+Enter")
+    await messageInput.press("Shift+Enter")
+
+    await messageInput.pressSequentially("This text should appear after three newlines")
+
+    await messageInput.press("Enter")
+
+    const expectedMessage = "Hello, this is a test message!\n\n\nThis text should appear after three newlines"
+    await expect(page.getByRole("paragraph").filter({hasText: expectedMessage})).toBeVisible()
+  })
+
+  test("New lines are trimmed but exist in the middle of the message", async ({page}) => {
+    await setupChat(page)
+
+    const messageInput = page.getByPlaceholder("Message")
+    await messageInput.fill("\nHello, this is a test message!\nThis is a new line\nThis is another new line\n")
+    
+    await messageInput.press("Enter")
+    
+    const expectedMessage = "Hello, this is a test message!\nThis is a new line\nThis is another new line"
+    await expect(page.getByRole("paragraph").filter({hasText: expectedMessage})).toBeVisible()
+  })
+
+  test("textarea resizes based on content", async ({page}) => {
+    await setupChat(page)
+
+    const messageInput = page.getByPlaceholder("Message")
+    
+    const initialHeight = await messageInput.evaluate(el => el.clientHeight)
+    
+    // Multiple newlines
+    await messageInput.pressSequentially("Line 1")
+    await messageInput.press("Shift+Enter")
+    await messageInput.press("Shift+Enter")
+    await messageInput.pressSequentially("Line 4")
+    
+    const heightAfterNewlines = await messageInput.evaluate(el => el.clientHeight)
+    expect(heightAfterNewlines).toBeGreaterThan(initialHeight)
+    
+    // Clear and verify height returns to initial
+    await messageInput.fill("")
+    const heightAfterClear = await messageInput.evaluate(el => el.clientHeight)
+    expect(heightAfterClear).toBe(initialHeight)
+    
+    // Long line that wraps
+    const longLine = "This is a very long line that should definitely wrap multiple times in the textarea because it contains a lot of text that needs to be displayed across multiple lines in the UI"
+    await messageInput.pressSequentially(longLine)
+    
+    const heightAfterWrapping = await messageInput.evaluate(el => el.clientHeight)
+    expect(heightAfterWrapping).toBeGreaterThan(initialHeight)
+    
+    // Clear again
+    await messageInput.fill("")
+    expect(await messageInput.evaluate(el => el.clientHeight)).toBe(initialHeight)
+    
+    // Combined newlines and wrapping
+    await messageInput.pressSequentially("First line with some text")
+    await messageInput.press("Shift+Enter")
+    await messageInput.pressSequentially(longLine)
+    await messageInput.press("Shift+Enter")
+    await messageInput.pressSequentially("Final line")
+    
+    const heightAfterCombined = await messageInput.evaluate(el => el.clientHeight)
+    expect(heightAfterCombined).toBeGreaterThan(heightAfterNewlines)
+    expect(heightAfterCombined).toBeGreaterThan(heightAfterWrapping)
+  })
+})
+


### PR DESCRIPTION
- `py-2.5 min-h-[2.5rem]` is for mobile to center vertically the message on 1 line
- No visual difference with sm and md so omitting difference styles for them
- `leading-tight` makes the box a bit smaller and neater
- `resize-none` since the hook does resizing for us based on line count
- Adds tests for trimming, newlines, wrap, textarea resize for Desktop

Notice:
- No E2E test for mobile 
  - Will make a separate PR for that since existing testing relies on text content and we should move to testing with specific classnames
  - Only different thing in mobile is the separate send button, so not too many paths untested now