### PR TITLE
Fix undefined tags in reply detection

### DIFF
--- a/src/utils/nostr.ts
+++ b/src/utils/nostr.ts
@@ -72,7 +72,8 @@ export function getEventReplyingTo(event: NDKEvent) {
     return undefined
   }
   const qEvent = event.tags?.find((tag) => tag[0] === "q")?.[1]
-  const replyTags = event.tags?.filter((tag) => tag[0] === "e" && tag[3] !== "mention")
+  const replyTags =
+    event.tags?.filter((tag) => tag[0] === "e" && tag[3] !== "mention") || []
   if (replyTags.length === 1 && replyTags[0][1] !== qEvent) {
     return replyTags[0][1]
   }


### PR DESCRIPTION
## Summary
- prevent crash in `getEventReplyingTo` when events are missing tags

## Testing
- `npx tsc src/utils/nostr.ts --noEmit` *(fails: cannot find namespace debug, etc.)*
- `yarn lint` *(fails: 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684949b791b8832bb8092df3327c706d