### PR TITLE
Show message content in in private chat notification

### DIFF
--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -3,6 +3,9 @@ import {
   INVITE_EVENT_KIND,
   INVITE_RESPONSE_KIND,
   MESSAGE_EVENT_KIND,
+  deserializeSessionState,
+  Session,
+  Rumor,
 } from "nostr-double-ratchet/src"
 import {PROFILE_AVATAR_WIDTH, EVENT_AVATAR_WIDTH} from "./shared/components/user/const"
 import {CacheFirst, StaleWhileRevalidate} from "workbox-strategies"
@@ -10,8 +13,10 @@ import {CacheableResponsePlugin} from "workbox-cacheable-response"
 import {precacheAndRoute, PrecacheEntry} from "workbox-precaching"
 import {generateProxyUrl} from "./shared/utils/imgproxy"
 import {ExpirationPlugin} from "workbox-expiration"
+import {VerifiedEvent} from "nostr-tools"
 import {registerRoute} from "workbox-routing"
 import {clientsClaim} from "workbox-core"
+import localforage from "localforage"
 
 // eslint-disable-next-line no-undef
 declare const self: ServiceWorkerGlobalScope & {
@@ -211,39 +216,120 @@ const NOTIFICATION_CONFIGS: Record<
   },
 } as const
 
-self.addEventListener("push", async (e) => {
-  const data = e.data?.json() as PushData | undefined
-  console.debug("Received web push data:", data)
+type DecryptResult =
+  | {
+      success: false
+    }
+  | {
+      success: true
+      content: string
+      sessionId: string
+    }
 
-  // Check if we should show notification based on page visibility
-  const clients = await self.clients.matchAll({type: "window", includeUncontrolled: true})
-  const isPageVisible = clients.some((client) => client.visibilityState === "visible")
-  if (isPageVisible) {
-    console.debug("Page is visible, ignoring web push")
-    return
+const tryDecryptPrivateDM = async (data: PushData): Promise<DecryptResult> => {
+  try {
+    const wrapper = await localforage.getItem("sessions")
+    if (wrapper) {
+      const parsed = typeof wrapper === "string" ? JSON.parse(wrapper) : wrapper
+      const sessionEntries: [string, string][] =
+        parsed?.state?.sessions ?? parsed?.sessions ?? []
+
+      for (const [sessionId, serState] of sessionEntries) {
+        const state = deserializeSessionState(serState)
+        const foundMatchingPubKey =
+          state.theirCurrentNostrPublicKey === data.event.pubkey ||
+          state.theirNextNostrPublicKey === data.event.pubkey
+
+        if (!foundMatchingPubKey) {
+          continue
+        }
+
+        const session = new Session((_, onEvent) => {
+          onEvent(data.event as unknown as VerifiedEvent)
+          return () => {}
+        }, state)
+
+        let unsubscribe: (() => void) | undefined
+        const innerEvent = await new Promise<Rumor | null>((resolve) => {
+          unsubscribe = session.onEvent((event) => {
+            resolve(event)
+          })
+        })
+
+        unsubscribe?.()
+
+        return innerEvent === null
+          ? {
+              success: false,
+            }
+          : {
+              success: true,
+              content: innerEvent.content,
+              sessionId,
+            }
+      }
+    }
+  } catch (err) {
+    console.error("DM decryption failed:", err)
   }
-
-  if (!data?.event) return
-
-  // Handle predefined notification types
-  if (NOTIFICATION_CONFIGS[data.event.kind]) {
-    const config = NOTIFICATION_CONFIGS[data.event.kind]
-    await self.registration.showNotification(config.title, {
-      icon: config.icon,
-      data: {url: config.url, event: data.event},
-    })
-    return
+  return {
+    success: false,
   }
+}
 
-  // Handle custom notifications
-  const icon =
-    data.icon && data.icon.startsWith("http")
-      ? generateProxyUrl(data.icon, {width: 128, square: true})
-      : data.icon || "/favicon.png"
+self.addEventListener("push", (event) => {
+  event.waitUntil(
+    (async () => {
+      // Check if we should show notification based on page visibility
+      const clients = await self.clients.matchAll({
+        type: "window",
+        includeUncontrolled: true,
+      })
+      const isPageVisible = clients.some((client) => client.visibilityState === "visible")
+      if (isPageVisible) {
+        console.debug("Page is visible, ignoring web push")
+        return
+      }
 
-  await self.registration.showNotification(data.title || "New notification", {
-    body: data.body,
-    icon,
-    data,
-  })
+      const data = event.data?.json() as PushData | undefined
+      if (!data?.event) return
+
+      if (data.event.kind === MESSAGE_EVENT_KIND) {
+        const result = await tryDecryptPrivateDM(data)
+        if (result.success) {
+          await self.registration.showNotification(
+            NOTIFICATION_CONFIGS[MESSAGE_EVENT_KIND].title,
+            {
+              body: result.content,
+              icon: NOTIFICATION_CONFIGS[MESSAGE_EVENT_KIND].icon,
+              data: {
+                url: `/chats/${encodeURIComponent(result.sessionId)}`,
+                event: data.event,
+              },
+            }
+          )
+          return
+        }
+      }
+
+      if (NOTIFICATION_CONFIGS[data.event.kind]) {
+        const config = NOTIFICATION_CONFIGS[data.event.kind]
+        await self.registration.showNotification(config.title, {
+          icon: config.icon,
+          data: {url: config.url, event: data.event},
+        })
+        return
+      }
+
+      const icon = data.icon?.startsWith("http")
+        ? generateProxyUrl(data.icon, {width: 128, square: true})
+        : data.icon || "/favicon.png"
+
+      await self.registration.showNotification(data.title || "New notification", {
+        body: data.body,
+        icon,
+        data,
+      })
+    })()
+  )
 })


### PR DESCRIPTION
Deserializes all sessions to find correct pubkey

Initializes a Session with a subscription that feeds the pushed message as an event instead of nostr subscription

Promisifies the onEvent to get the decrypted innerEvent

Falls back to the old implementation when decrypting fails

Doesn't write new state anywhere - assumes we get the events when opening the app