### PR TITLE
fix: Unread badge visible without initial visit to the chat

### DIFF
--- a/src/shared/components/messages/UnseenMessagesBadge.tsx
+++ b/src/shared/components/messages/UnseenMessagesBadge.tsx
@@ -16,7 +16,6 @@ export default function UnseenMessagesBadge() {
       const latestTime = getMillisecondTimestamp(latest)
       const lastSeenTime = lastSeen.get(sessionId)
 
-      // If no lastSeen exists, don't show as unread (new sessions)
       if (lastSeenTime === undefined) return false
 
       return latestTime > lastSeenTime


### PR DESCRIPTION
- initialize lastSeen on accepting invite so we can compare to message timestamp
- refactor some copypaste code to reduce errors
